### PR TITLE
Fixing drawer panel overlap

### DIFF
--- a/fs-gallery-view-selector.html
+++ b/fs-gallery-view-selector.html
@@ -45,10 +45,19 @@ Example:
         outline: none;
       }
 
+      @media screen and (max-width: 979px) {
+        :host {
+          position: relative;
+          top: 56px;
+        }
+      }
+
       ul {
         list-style: none;
         margin:0;
         padding:0;
+        overflow: scroll;
+        height: calc(100% - 56px);
       }
 
       ul:focus {


### PR DESCRIPTION
This will help fix the paper-drawer-panel from being overlapped when viewed on a tablet or phone.