### PR TITLE
Accounting for added `flex` styling

### DIFF
--- a/fs-gallery-view-selector.html
+++ b/fs-gallery-view-selector.html
@@ -221,7 +221,12 @@ Example:
       *[hidden] {
         display: none !important;
       }
-
+      .albumDiv {
+        display: block;
+      }
+      .albumDiv span {
+        margin-left: 5px;
+      }
     </style>
     <template is='dom-if' if="[[!readOnly]]">
       <iron-ajax
@@ -284,7 +289,7 @@ Example:
           </li>
         </template>
         <li id='newAlbumView' hidden$='[[!_addingAlbum]]'>
-          <div class='add-album'>
+          <div class='add-album albumDiv'>
             <button id='closeButton' class="fs-icon fs-icon-close close-button" aria-label="Close modal" on-tap='_handleCancelNewAlbum'>&nbsp;</button>
             <iron-a11y-keys target="[[_albumInput]]" keys="esc" on-keys-pressed="_toggleAddAlbum"></iron-a11y-keys>
             <iron-a11y-keys target="[[_albumInput]]" keys="enter" on-keys-pressed="_createNewAlbum"></iron-a11y-keys>

--- a/fs-gallery-view-selector.html
+++ b/fs-gallery-view-selector.html
@@ -65,11 +65,16 @@ Example:
       }
 
       .add-album {
+        display: block;
         margin: -2px -5px;
         padding: 10px;
         background: #f4f4f4;
       }
 
+      .add-album span {
+        margin-left: 5px;
+      }
+      
       input.album-title-input {
         margin-bottom: 5px;
       }
@@ -221,12 +226,6 @@ Example:
       *[hidden] {
         display: none !important;
       }
-      .albumDiv {
-        display: block;
-      }
-      .albumDiv span {
-        margin-left: 5px;
-      }
     </style>
     <template is='dom-if' if="[[!readOnly]]">
       <iron-ajax
@@ -289,7 +288,7 @@ Example:
           </li>
         </template>
         <li id='newAlbumView' hidden$='[[!_addingAlbum]]'>
-          <div class='add-album albumDiv'>
+          <div class='add-album'>
             <button id='closeButton' class="fs-icon fs-icon-close close-button" aria-label="Close modal" on-tap='_handleCancelNewAlbum'>&nbsp;</button>
             <iron-a11y-keys target="[[_albumInput]]" keys="esc" on-keys-pressed="_toggleAddAlbum"></iron-a11y-keys>
             <iron-a11y-keys target="[[_albumInput]]" keys="enter" on-keys-pressed="_createNewAlbum"></iron-a11y-keys>


### PR DESCRIPTION
There was a style added to add `display:flex` to `li > div` when the "add-album" div needs to not be flex
Also added spacing back to span