### PR TITLE
Ditching `important` flag to allow `fs-artifact-selector` 

### DIFF
--- a/fs-gallery-view-selector.html
+++ b/fs-gallery-view-selector.html
@@ -35,7 +35,7 @@ Example:
       :host {
         display: inline-block;
         width:200px;
-        height:calc(100% - 65px) !important;
+        height:calc(100% - 65px);
         overflow: scroll;
         -webkit-overflow-scrolling: touch;
         --album-border-style: 1px solid #d2d2d2;
@@ -50,7 +50,7 @@ Example:
         :host {
           position: relative;
           top: 56px;
-          height: calc(100% - 70px) !important;
+          height: calc(100% - 70px);
         }
       }
 


### PR DESCRIPTION
to account for scrolling on mobile