### PR TITLE
Specifying overflow-y for scroll

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-gallery-view-selector",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "authors": [
     "Josh Crowther <jshcrowthe@gmail.com>"
   ],

--- a/fs-gallery-view-selector.html
+++ b/fs-gallery-view-selector.html
@@ -36,7 +36,7 @@ Example:
         display: inline-block;
         width:200px;
         height:calc(100% - 65px);
-        overflow: scroll;
+        overflow-y: scroll;
         -webkit-overflow-scrolling: touch;
         --album-border-style: 1px solid #d2d2d2;
         border-right: var(--album-border-style);


### PR DESCRIPTION
Previously overflow-x would also inherit scrolling, which adds a bottom scrollbar on browsers where "always show scrollbars" is enabled.

Fixes JIRA [PS-3675](https://almtools.ldschurch.org/fhjira/browse/PS-3675)