### PR TITLE
Apply white background to entire view selector

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-gallery-view-selector",
-  "version": "5.2.6",
+  "version": "5.2.7",
   "authors": [
     "Josh Crowther <jshcrowthe@gmail.com>"
   ],

--- a/fs-gallery-view-selector.html
+++ b/fs-gallery-view-selector.html
@@ -41,6 +41,7 @@ Example:
         -webkit-overflow-scrolling: touch;
         --album-border-style: 1px solid #d2d2d2;
         border-right: var(--album-border-style);
+        background: white;
       }
 
       :host:focus, ::content:focus {
@@ -153,7 +154,6 @@ Example:
         padding: 2px 5px;
         box-sizing: border-box;
         -moz-box-sizing: border-box;
-        background: white;
       }
 
       li:first-child,


### PR DESCRIPTION
Moving the white background CSS from the list item to the container ensures the whole selector has a white background even if list items don't extend to the bottom